### PR TITLE
feat: implement pagination for room and room type retrieval endpoints

### DIFF
--- a/src/modules/room/room.controller.ts
+++ b/src/modules/room/room.controller.ts
@@ -18,6 +18,9 @@ import { JwtAccessTokenGuard } from '../auth/guards/jwt-access-token.guard';
 import { Roles } from '@/decorators/roles.decorator';
 import { UserRole } from '../user/entities/user.entity';
 import { ApiBodyWithFiles } from '@/decorators/apiBodyWithFiles.decorator';
+import { ApiPaginationQuery } from '@/decorators/apiPaginationQuery.decorator';
+import { PaginateData, PaginateParams } from '@/types/common.type';
+import { Query } from '@nestjs/common';
 
 @Controller('rooms')
 @UseGuards(JwtAccessTokenGuard, RolesGuard)
@@ -48,8 +51,9 @@ export class RoomController {
 	}
 
 	@Get()
-	findAll(): Promise<Room[]> {
-		return this.roomService.findAll();
+	@ApiPaginationQuery()
+	findAll(@Query() query: PaginateParams): Promise<PaginateData<Room>> {
+		return this.roomService.findAll(query);
 	}
 
 	@Get(':id')
@@ -58,8 +62,12 @@ export class RoomController {
 	}
 
 	@Get('roomType/:roomTypeId')
-	findByRoomTypeId(@Param('roomTypeId') roomTypeId: string): Promise<Room[]> {
-		return this.roomService.findByRoomTypeId(roomTypeId);
+	@ApiPaginationQuery()
+	findByRoomTypeId(
+		@Param('roomTypeId') roomTypeId: string,
+		@Query() query: PaginateParams,
+	): Promise<PaginateData<Room>> {
+		return this.roomService.findByRoomTypeId(roomTypeId, query);
 	}
 
 	@Patch(':id')

--- a/src/modules/roomType/roomType.controller.ts
+++ b/src/modules/roomType/roomType.controller.ts
@@ -16,6 +16,9 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { JwtAccessTokenGuard } from '../auth/guards/jwt-access-token.guard';
 import { Roles } from '@/decorators/roles.decorator';
 import { UserRole } from '../user/entities/user.entity';
+import { ApiPaginationQuery } from '@/decorators/apiPaginationQuery.decorator';
+import { PaginateData, PaginateParams } from '@/types/common.type';
+import { Query } from '@nestjs/common';
 
 @Controller('room-types')
 @UseGuards(JwtAccessTokenGuard, RolesGuard)
@@ -29,8 +32,9 @@ export class RoomTypeController {
 	}
 
 	@Get()
-	findAll(): Promise<RoomType[]> {
-		return this.roomTypeService.findAll();
+	@ApiPaginationQuery()
+	findAll(@Query() query: PaginateParams): Promise<PaginateData<RoomType>> {
+		return this.roomTypeService.findAll(query);
 	}
 
 	@Get(':id')

--- a/src/types/common.type.ts
+++ b/src/types/common.type.ts
@@ -2,8 +2,8 @@ import { BaseEntity } from '@/modules/shared/base/base.entity';
 import { ApiProperty } from '@nestjs/swagger';
 
 export enum SORT_TYPE {
-	'DESC' = 'desc',
-	'ASC' = 'acs',
+	DESC = 'desc',
+	ASC = 'asc',
 }
 
 export type FindAllResponse<T> = { count: number; items: T[] };
@@ -38,5 +38,5 @@ export class PaginateData<T extends BaseEntity> {
 export type PaginateParams = {
 	page: number;
 	limit: number;
-	sort: string;
+	sort?: SORT_TYPE;
 };


### PR DESCRIPTION
This pull request introduces pagination support for the `Room` and `RoomType` modules. The changes include modifications to the controllers and services to handle pagination parameters and responses.

### Pagination support:

* [`src/modules/room/room.controller.ts`](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R21-R23): Added `ApiPaginationQuery` decorator and updated `findAll` and `findByRoomTypeId` methods to accept `PaginateParams` and return `PaginateData<Room>`. [[1]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R21-R23) [[2]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5L51-R56) [[3]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5L61-R70)
* [`src/modules/room/room.service.ts`](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8R16): Modified `findAll` and `findByRoomTypeId` methods to handle pagination logic and return `PaginateData<Room>`. [[1]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8R16) [[2]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8L49-R78) [[3]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8L61-R120)
* [`src/modules/roomType/roomType.controller.ts`](diffhunk://#diff-60bc3d357112e6f0c832a335410539451a215938bb2e72385378d347854f26a7R19-R21): Added `ApiPaginationQuery` decorator and updated `findAll` method to accept `PaginateParams` and return `PaginateData<RoomType>`. [[1]](diffhunk://#diff-60bc3d357112e6f0c832a335410539451a215938bb2e72385378d347854f26a7R19-R21) [[2]](diffhunk://#diff-60bc3d357112e6f0c832a335410539451a215938bb2e72385378d347854f26a7L32-R37)
* [`src/modules/roomType/roomType.service.ts`](diffhunk://#diff-6c7ea82de8bcba3e2a3c8eeb130d51362726efec03f82e491fc8552454568303R7): Modified `findAll` method to handle pagination logic and return `PaginateData<RoomType>`. [[1]](diffhunk://#diff-6c7ea82de8bcba3e2a3c8eeb130d51362726efec03f82e491fc8552454568303R7) [[2]](diffhunk://#diff-6c7ea82de8bcba3e2a3c8eeb130d51362726efec03f82e491fc8552454568303L19-R48)

### Type updates:

* [`src/types/common.type.ts`](diffhunk://#diff-7e698152d2abba5b6031fcec8304c1ec6fa684d683183cec60d484220d967f1fL5-R6): Corrected the `SORT_TYPE` enum and updated the `PaginateParams` type to make the `sort` property optional. [[1]](diffhunk://#diff-7e698152d2abba5b6031fcec8304c1ec6fa684d683183cec60d484220d967f1fL5-R6) [[2]](diffhunk://#diff-7e698152d2abba5b6031fcec8304c1ec6fa684d683183cec60d484220d967f1fL41-R41)