### PR TITLE
feat: hash user passwords during creation for enhanced security

### DIFF
--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,6 +1,7 @@
 import { BaseServiceAbstract } from '@/services/base/base.abstract.service';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 import { isValidObjectId } from 'mongoose';
+import * as bcrypt from 'bcryptjs';
 import { ImgurService } from '../imgur/imgur.service';
 import { ChangeProfileRequestDTO } from './dto/request/changeProfile.request.dto';
 import { User } from './entities/user.entity';
@@ -9,6 +10,8 @@ import { CreateUserRequestDTO } from './dto/request/createUser.request.dto';
 
 @Injectable()
 export class UserService extends BaseServiceAbstract<User> {
+	private readonly SALT_ROUND = 10;
+
 	constructor(
 		@Inject('UsersRepositoryInterface')
 		private readonly userRepo: UserRepositoryInterface,
@@ -18,7 +21,14 @@ export class UserService extends BaseServiceAbstract<User> {
 	}
 
 	async create(createUserRequestDTO: CreateUserRequestDTO): Promise<User> {
-		return this.userRepo.create(createUserRequestDTO);
+		const hashedPassword = await bcrypt.hash(
+			createUserRequestDTO.password,
+			this.SALT_ROUND,
+		);
+		return this.userRepo.create({
+			...createUserRequestDTO,
+			password: hashedPassword,
+		});
 	}
 
 	async getUser(data: string): Promise<User> {


### PR DESCRIPTION
This pull request introduces changes to the `UserService` class in `src/modules/user/user.service.ts` to enhance password security by hashing user passwords before storing them. The most important changes include importing the `bcryptjs` library, adding a constant for the salt rounds, and modifying the `create` method to hash passwords.

Enhancements to password security:

* [`src/modules/user/user.service.ts`](diffhunk://#diff-441c6d6bbdd25c5fbdc366d06b7b4d6be55a7e6e1196bd71dd1d916cbdc8e423R4): Imported the `bcryptjs` library for password hashing.
* [`src/modules/user/user.service.ts`](diffhunk://#diff-441c6d6bbdd25c5fbdc366d06b7b4d6be55a7e6e1196bd71dd1d916cbdc8e423R13-R14): Added a constant `SALT_ROUND` set to 10 for use in password hashing.
* [`src/modules/user/user.service.ts`](diffhunk://#diff-441c6d6bbdd25c5fbdc366d06b7b4d6be55a7e6e1196bd71dd1d916cbdc8e423L21-R31): Modified the `create` method to hash the user's password using `bcryptjs` before storing it in the database.