### PR TITLE
feat: calculate total amount based on the number of nights for bookings

### DIFF
--- a/src/modules/booking/booking.service.ts
+++ b/src/modules/booking/booking.service.ts
@@ -53,8 +53,10 @@ export class BookingService {
 				'Check-in date must be before check-out date',
 			);
 		}
-
-		let totalAmount = room.pricePerNight;
+		const totalNight =
+			(dto.checkoutDate.getTime() - dto.checkinDate.getTime()) /
+			(1000 * 60 * 60 * 24);
+		let totalAmount = room.pricePerNight * totalNight;
 
 		if (dto.promotionId) {
 			try {
@@ -245,10 +247,14 @@ export class BookingService {
 
 		const room = booking.roomId as unknown as Room;
 
+		const totalNight =
+			(booking.checkoutDate.getTime() - booking.checkinDate.getTime()) /
+			(1000 * 60 * 60 * 24);
+
 		const items = [
 			{
 				name: room.roomNumber,
-				quantity: 1,
+				quantity: totalNight,
 				price: room.pricePerNight,
 			},
 			...booking.services.map((service) => ({


### PR DESCRIPTION
This pull request includes changes to the `BookingService` class in the `src/modules/booking/booking.service.ts` file. The changes primarily focus on calculating the total number of nights for a booking and using this value to determine the total amount and the quantity of room items.

Key changes include:

* Calculation of total nights:
  * Added a calculation for `totalNight` by subtracting the check-in date from the check-out date and converting the result from milliseconds to days. This change ensures the total number of nights is accurately calculated. [[1]](diffhunk://#diff-b5a7938ee79396bd5d2b13a7daacdf1ea5facaab73b95c0b4dfd044004c2a5c1L56-R59) [[2]](diffhunk://#diff-b5a7938ee79396bd5d2b13a7daacdf1ea5facaab73b95c0b4dfd044004c2a5c1R250-R257)
  
* Update to total amount and item quantity:
  * Modified the calculation of `totalAmount` to multiply the room's price per night by the total number of nights.
  * Updated the `quantity` field in the `items` array to use `totalNight` instead of a fixed value of 1.