### PR TITLE
feat: update rating calculation logic and remove ratings reference from room entity

### DIFF
--- a/src/modules/rating/rating.service.ts
+++ b/src/modules/rating/rating.service.ts
@@ -29,12 +29,10 @@ export class RatingService {
 		});
 
 		const savedRating = await rating.save();
-		console.log('room', room);
 		const ratings = await this.ratingModel
 			.find({ roomId: room._id })
 			.select('id');
 
-		console.log('ratings', ratings);
 		const averageRating = await this.calculateAverageRating(
 			ratings.map((r) => r.id),
 		);

--- a/src/modules/rating/rating.service.ts
+++ b/src/modules/rating/rating.service.ts
@@ -29,9 +29,16 @@ export class RatingService {
 		});
 
 		const savedRating = await rating.save();
+		console.log('room', room);
+		const ratings = await this.ratingModel
+			.find({ roomId: room._id })
+			.select('id');
 
-		room.ratings.push(savedRating._id as Types.ObjectId);
-		room.averageRating = await this.calculateAverageRating(room.ratings);
+		console.log('ratings', ratings);
+		const averageRating = await this.calculateAverageRating(
+			ratings.map((r) => r.id),
+		);
+		room.averageRating = averageRating;
 		await room.save();
 
 		return savedRating;

--- a/src/modules/room/entities/room.entity.ts
+++ b/src/modules/room/entities/room.entity.ts
@@ -33,8 +33,8 @@ export class Room extends BaseEntity {
 	@Prop({ type: [String], default: [] })
 	images: string[];
 
-	@Prop({ type: [{ type: Types.ObjectId, ref: 'Rating' }], default: [] })
-	ratings: Types.ObjectId[];
+	// @Prop({ type: [{ type: Types.ObjectId, ref: 'Rating' }], default: [] })
+	// ratings: Types.ObjectId[];
 
 	@Prop({ type: Number, default: 0 })
 	averageRating: number;


### PR DESCRIPTION
This pull request includes changes to the rating and room entities to improve the handling and calculation of average ratings. The most important changes involve modifying the `RatingService` and `Room` entity to simplify the rating calculation process and remove the direct storage of ratings in the `Room` entity.

Changes to rating calculation:

* [`src/modules/rating/rating.service.ts`](diffhunk://#diff-0c7f4a0c0b0d6ab8bb87eac60a547f6e0ad7234bc8e04e8c3d57f796d4d817fcR32-R41): Updated the rating calculation logic to fetch ratings by `roomId` and calculate the average rating using the fetched ratings instead of directly accessing and storing rating IDs in the `Room` entity.

Changes to room entity:

* [`src/modules/room/entities/room.entity.ts`](diffhunk://#diff-5838b28de69f54a24555dfb1e48cb545c23f1515e9b05ba8fc895bc47fb6ac11L36-R37): Commented out the `ratings` property in the `Room` entity to remove the direct storage of rating IDs.