### PR TITLE
feat: enhance booking service status count by incorporating user role filtering

### DIFF
--- a/src/modules/booking/booking.controller.ts
+++ b/src/modules/booking/booking.controller.ts
@@ -286,10 +286,11 @@ export class BookingController {
 			},
 		},
 	})
-	async getBookingServiceCountByStatus(): Promise<{
+	async getBookingServiceCountByStatus(@Req() req: RequestWithUser): Promise<{
 		pending: number;
 		served: number;
 	}> {
-		return this.bookingService.getServiceStatusCount();
+		const { user } = req;
+		return this.bookingService.getServiceStatusCount(user);
 	}
 }


### PR DESCRIPTION
This pull request includes changes to the `BookingController` and `BookingService` classes to add user context when fetching booking service counts. The most important changes include updating the `getBookingServiceCountByStatus` method to accept a user request and modifying the service status count logic to filter results based on the user's role and associated service type.

Changes to `BookingController`:

* [`src/modules/booking/booking.controller.ts`](diffhunk://#diff-63d1bd32c72c4c9d8e5fa1c29bae9cbb937a6bed242ae7ec6fe9411179b261b9L289-R294): Updated the `getBookingServiceCountByStatus` method to accept a `RequestWithUser` parameter and pass the user to the service method.

Changes to `BookingService`:

* [`src/modules/booking/booking.service.ts`](diffhunk://#diff-b5a7938ee79396bd5d2b13a7daacdf1ea5facaab73b95c0b4dfd044004c2a5c1L430-R467): Modified the `getServiceStatusCount` method to accept a `User` parameter and filter bookings based on the user's role and service type.