### PR TITLE
refactor: add endpoint to retrieve yearly revenue data in Admin Dashboard

### DIFF
--- a/src/modules/admin-dashboard/admin-dashboard.controller.ts
+++ b/src/modules/admin-dashboard/admin-dashboard.controller.ts
@@ -35,6 +35,33 @@ export class AdminDashboardController {
 		return this.adminDashboardService.getDailyRevenue();
 	}
 
+	@Get('yearly-revenue')
+	@Roles(UserRole.Admin)
+	@ApiOperation({ summary: 'Get yearly revenue' })
+	@ApiResponse({
+		status: 200,
+		description: 'Yearly revenue',
+		schema: {
+			type: 'object',
+			properties: {
+				currentYearRevenue: { type: 'number' },
+				lastYearRevenue: { type: 'number' },
+				currentYearMonthlyRevenue: {
+					type: 'array',
+					items: { type: 'number' },
+				},
+				lastYearMonthlyRevenue: {
+					type: 'array',
+					items: { type: 'number' },
+				},
+				growth: { type: 'number' },
+			},
+		},
+	})
+	async getYearlyRevenue() {
+		return this.adminDashboardService.getYearlyRevenue();
+	}
+
 	@Get('daily-customer-growth')
 	@Roles(UserRole.Admin)
 	@ApiOperation({ summary: 'Get daily customer growth percentage' })


### PR DESCRIPTION
This pull request introduces a new endpoint to the `AdminDashboardController` to retrieve yearly revenue data. The most important change is the addition of the `getYearlyRevenue` method, which includes appropriate route, role, and API documentation annotations.

New endpoint addition:

* [`src/modules/admin-dashboard/admin-dashboard.controller.ts`](diffhunk://#diff-cc3d859f6ecdab3197d608f028734873173030df8cda679f16345f037f8650a7R38-R64): Added `getYearlyRevenue` method to retrieve yearly revenue, including route definition (`Get('yearly-revenue')`), role restriction (`@Roles(UserRole.Admin)`), and API documentation (`@ApiOperation` and `@ApiResponse`).