### PR TITLE
fix: ensure promotionId defaults to null if not provided

### DIFF
--- a/src/modules/booking/booking.service.ts
+++ b/src/modules/booking/booking.service.ts
@@ -162,7 +162,7 @@ export class BookingService {
 			checkinDate: dto.checkinDate,
 			checkoutDate: dto.checkoutDate,
 			services: bookingServices,
-			promotionId: dto.promotionId,
+			promotionId: dto.promotionId || null,
 			totalAmount,
 			status: BookingStatus.Pending,
 			guests: dto.guests,


### PR DESCRIPTION
This pull request includes a small change to the `BookingService` class in the `src/modules/booking/booking.service.ts` file. The change ensures that the `promotionId` is set to `null` if it is not provided in the `dto`.

* [`src/modules/booking/booking.service.ts`](diffhunk://#diff-b5a7938ee79396bd5d2b13a7daacdf1ea5facaab73b95c0b4dfd044004c2a5c1L165-R165): Modified the `promotionId` assignment to default to `null` if `dto.promotionId` is not provided.