### PR TITLE
feat: add pagination support to room filtering and enhance query parameters

### DIFF
--- a/src/modules/room/room.controller.ts
+++ b/src/modules/room/room.controller.ts
@@ -123,15 +123,29 @@ export class RoomController {
 		enum: ['asc', 'desc'],
 		description: 'Sort order (asc/desc)',
 	})
+	@ApiQuery({
+		name: 'page',
+		required: false,
+		type: Number,
+		description: 'Page number',
+	})
+	@ApiQuery({
+		name: 'limit',
+		required: false,
+		type: Number,
+		description: 'Items per page',
+	})
 	async filterRoomsByRoomTypeFields(
-		@Query('amenities') amenities?: string[],
+		@Query('amenities') amenitiesRaw?: string | string[],
 		@Query('guestAmount') guestAmountRaw?: string,
 		@Query('bedAmount') bedAmountRaw?: string,
 		@Query('bedroomAmount') bedroomAmountRaw?: string,
 		@Query('searchKeyFeature') searchKeyFeature?: string,
-		@Query('sortBy') sortBy?: 'pricePerNight' | 'averageRating',
+		@Query('sortBy') sortBy?: 'averageRating' | 'pricePerNight',
 		@Query('sortOrder') sortOrder?: 'asc' | 'desc',
-	): Promise<Room[]> {
+		@Query('page') page = 1,
+		@Query('limit') limit = 10,
+	): Promise<PaginateData<Room>> {
 		const guestAmount = guestAmountRaw
 			? parseInt(guestAmountRaw, 10)
 			: undefined;
@@ -139,10 +153,11 @@ export class RoomController {
 		const bedroomAmount = bedroomAmountRaw
 			? parseInt(bedroomAmountRaw, 10)
 			: undefined;
-
-		if (amenities && !Array.isArray(amenities)) {
-			amenities = [amenities];
-		}
+		const amenities = Array.isArray(amenitiesRaw)
+			? amenitiesRaw
+			: amenitiesRaw
+				? [amenitiesRaw]
+				: undefined;
 
 		return this.roomService.filterRoomsByRoomTypeFields(
 			amenities,
@@ -152,6 +167,8 @@ export class RoomController {
 			searchKeyFeature,
 			sortBy,
 			sortOrder as 'asc' | 'desc',
+			page,
+			limit,
 		);
 	}
 


### PR DESCRIPTION
This pull request introduces pagination to the `RoomController` and `RoomService` classes, enhancing the API's ability to handle large datasets by breaking them into manageable pages. The key changes include adding pagination parameters and modifying the service to return paginated results.

### Enhancements to RoomController:

* Added `page` and `limit` query parameters to the `filterRoomsByRoomTypeFields` method to enable pagination.
* Updated the method signature to return a `PaginateData<Room>` object instead of a `Room[]`, reflecting the new paginated response structure.
* Passed the new `page` and `limit` parameters to the service method.

### Enhancements to RoomService:

* Added `page` and `limit` parameters to the `filterRoomsByRoomTypeFields` method and calculated the `skip` value for pagination.
* Included a `$project` stage in the aggregation pipeline to shape the returned documents.
* Modified the aggregation pipeline to include pagination logic, counting total documents, and calculating pagination metadata.