### PR TITLE
feat: add userId to refresh token request and enhance room filtering with shared bath amount

### DIFF
--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -128,6 +128,7 @@ export default async () => {
 					{
 						RefreshTokenRequestDTO: {
 							refreshToken: { required: true, type: () => String },
+							userId: { required: true, type: () => String },
 						},
 					},
 				],

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -103,13 +103,15 @@ export class AuthController {
 		return await this.userService.getUser(user.email);
 	}
 
-	@UseGuards(JwtRefreshTokenGuard)
 	@ApiPost({ path: 'refresh-token' })
 	@ApiBody({
 		type: RefreshTokenRequestDTO,
 	})
-	async refreshAccessToken(@Req() request: RequestWithUser) {
-		const { user } = request;
+	async refreshAccessToken(@Body() dto: RefreshTokenRequestDTO) {
+		const user = await this.authService.getUserIfRefreshTokenMatched(
+			dto.userId,
+			dto.refreshToken,
+		);
 		const accessToken = this.authService.generateAccessToken({
 			userID: user._id.toString(),
 		});

--- a/src/modules/auth/dto/request/refreshToken.request.dto.ts
+++ b/src/modules/auth/dto/request/refreshToken.request.dto.ts
@@ -4,4 +4,8 @@ export class RefreshTokenRequestDTO {
 	@IsNotEmpty()
 	@IsString()
 	refreshToken: string;
+
+	@IsNotEmpty()
+	@IsString()
+	userId: string;
 }

--- a/src/modules/room/room.controller.ts
+++ b/src/modules/room/room.controller.ts
@@ -110,6 +110,7 @@ export class RoomController {
 	@ApiQuery({ name: 'guestAmount', required: false, type: Number })
 	@ApiQuery({ name: 'bedAmount', required: false, type: Number })
 	@ApiQuery({ name: 'bedroomAmount', required: false, type: Number })
+	@ApiQuery({ name: 'sharedBathAmount', required: false, type: Number })
 	@ApiQuery({ name: 'searchKeyFeature', required: false, type: String })
 	@ApiQuery({
 		name: 'sortBy',
@@ -152,6 +153,7 @@ export class RoomController {
 		@Query('guestAmount') guestAmountRaw?: string,
 		@Query('bedAmount') bedAmountRaw?: string,
 		@Query('bedroomAmount') bedroomAmountRaw?: string,
+		@Query('sharedBathAmount') sharedBathAmountRaw?: string,
 		@Query('searchKeyFeature') searchKeyFeature?: string,
 		@Query('sortBy') sortBy?: 'averageRating' | 'pricePerNight',
 		@Query('sortOrder') sortOrder?: 'asc' | 'desc',
@@ -167,6 +169,9 @@ export class RoomController {
 		const bedroomAmount = bedroomAmountRaw
 			? parseInt(bedroomAmountRaw, 10)
 			: undefined;
+		const sharedBathAmount = sharedBathAmountRaw
+			? parseInt(sharedBathAmountRaw, 10)
+			: undefined;
 		const amenities = Array.isArray(amenitiesRaw)
 			? amenitiesRaw
 			: amenitiesRaw
@@ -180,6 +185,7 @@ export class RoomController {
 			guestAmount,
 			bedAmount,
 			bedroomAmount,
+			sharedBathAmount,
 			searchKeyFeature,
 			sortBy,
 			sortOrder as 'asc' | 'desc',

--- a/src/modules/room/room.service.ts
+++ b/src/modules/room/room.service.ts
@@ -429,6 +429,7 @@ export class RoomService {
 		guestAmount?: number,
 		bedAmount?: number,
 		bedroomAmount?: number,
+		sharedBathAmount?: number,
 		searchKeyFeature?: string,
 		sortBy?: 'averageRating' | 'pricePerNight',
 		sortOrder: 'asc' | 'desc' = 'desc',
@@ -517,6 +518,9 @@ export class RoomService {
 		}
 		if (bedroomAmount !== undefined) {
 			match['roomType.bedroomAmount'] = { $gte: bedroomAmount };
+		}
+		if (sharedBathAmount !== undefined) {
+			match['roomType.sharedBathAmount'] = { $gte: sharedBathAmount };
 		}
 		if (searchKeyFeature) {
 			match.$or = [


### PR DESCRIPTION
This pull request includes several changes to the authentication and room modules to enhance functionality. The most significant changes are the addition of a `userId` field to the refresh token request and the inclusion of `sharedBathAmount` in room queries and services.

### Authentication Module Changes:
* Added `userId` field to `RefreshTokenRequestDTO` to be required and of type `String` in `src/metadata.ts`.
* Updated `RefreshTokenRequestDTO` class to include the `userId` field in `src/modules/auth/dto/request/refreshToken.request.dto.ts`.
* Modified `AuthController` to use the new `userId` field for refreshing access tokens in `src/modules/auth/auth.controller.ts`.

### Room Module Changes:
* Added `sharedBathAmount` query parameter to `RoomController` in `src/modules/room/room.controller.ts` [[1]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R113) [[2]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R156) [[3]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R172-R174) [[4]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R188).
* Updated `RoomService` to handle `sharedBathAmount` in room queries in `src/modules/room/room.service.ts` [[1]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8R432) [[2]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8R522-R524).