### PR TITLE
feat: add next available week calculation to room availability query

### DIFF
--- a/src/modules/room/room.service.ts
+++ b/src/modules/room/room.service.ts
@@ -495,12 +495,18 @@ export class RoomService {
 						$let: {
 							vars: {
 								nextWeekStart: {
-									$add: [
-										{
-											$max: '$bookings.checkoutDate',
+									$cond: {
+										if: { $eq: [{ $size: '$bookings' }, 0] },
+										then: new Date(),
+										else: {
+											$add: [
+												{
+													$max: '$bookings.checkoutDate',
+												},
+												1 * 24 * 60 * 60 * 1000,
+											],
 										},
-										1 * 24 * 60 * 60 * 1000,
-									],
+									},
 								},
 							},
 							in: {

--- a/src/modules/room/room.service.ts
+++ b/src/modules/room/room.service.ts
@@ -4,7 +4,7 @@ import {
 	BadRequestException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
+import { Model } from 'mongoose';
 import { CreateRoomDTO } from './dto/createRoom.dto';
 import { UpdateRoomDTO } from './dto/updateRoom.dto';
 import { Room, RoomDocument } from './entities/room.entity';
@@ -465,21 +465,6 @@ export class RoomService {
 				},
 			},
 			{
-				$project: {
-					id: '$_id',
-					roomNumber: 1,
-					roomTypeId: 1,
-					status: 1,
-					pricePerNight: 1,
-					images: 1,
-					averageRating: 1,
-					roomType: '$roomType',
-					roomTypeName: '$roomType.typeName',
-					bookingCount: { $size: { $ifNull: ['$bookings', []] } },
-					bookings: 1,
-				},
-			},
-			{
 				$addFields: {
 					isAvailable: {
 						$not: {
@@ -502,6 +487,46 @@ export class RoomService {
 			{
 				$match: {
 					isAvailable: true,
+				},
+			},
+			{
+				$addFields: {
+					nextAvailableWeek: {
+						$let: {
+							vars: {
+								nextWeekStart: {
+									$add: [
+										{
+											$max: '$bookings.checkoutDate',
+										},
+										1 * 24 * 60 * 60 * 1000,
+									],
+								},
+							},
+							in: {
+								start: '$$nextWeekStart',
+								end: {
+									$add: ['$$nextWeekStart', 7 * 24 * 60 * 60 * 1000],
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				$project: {
+					id: '$_id',
+					roomNumber: 1,
+					roomTypeId: 1,
+					status: 1,
+					pricePerNight: 1,
+					images: 1,
+					averageRating: 1,
+					roomType: '$roomType',
+					roomTypeName: '$roomType.typeName',
+					bookingCount: { $size: { $ifNull: ['$bookings', []] } },
+					bookings: 1,
+					nextAvailableWeek: 1,
 				},
 			},
 		];


### PR DESCRIPTION
This pull request to `src/modules/room/room.service.ts` includes changes to enhance the room service functionality by removing redundant code and adding new fields to the room aggregation pipeline. The most important changes are listed below:

### Code Cleanup:

* Removed the unnecessary import of `Types` from `mongoose` since it is not being used in the file.

### Enhancements to Room Aggregation:

* Removed the `$project` stage that was previously used to shape the room data, as it has been replaced by a more comprehensive `$project` stage later in the pipeline.
* Added a new field `nextAvailableWeek` to the aggregation pipeline, which calculates the next available week for a room based on the maximum checkout date of existing bookings.
* Reintroduced the `$project` stage at the end of the pipeline to include the new `nextAvailableWeek` field along with other room details such as `id`, `roomNumber`, `roomTypeId`, `status`, `pricePerNight`, `images`, `averageRating`, `roomType`, `roomTypeName`, `bookingCount`, and `bookings`.