### PR TITLE
feat: add roomTypeId query parameter to filter rooms by type

### DIFF
--- a/src/modules/room/room.controller.ts
+++ b/src/modules/room/room.controller.ts
@@ -148,6 +148,12 @@ export class RoomController {
 		type: Date,
 		description: 'Check-out date',
 	})
+	@ApiQuery({
+		name: 'roomTypeId',
+		required: false,
+		type: String,
+		description: 'Room Type ID',
+	})
 	async filterRoomsByRoomTypeFields(
 		@Query('amenities') amenitiesRaw?: string | string[],
 		@Query('guestAmount') guestAmountRaw?: string,
@@ -161,6 +167,7 @@ export class RoomController {
 		@Query('limit') limit = 10,
 		@Query('checkinDate') checkinDate?: string,
 		@Query('checkoutDate') checkoutDate?: string,
+		@Query('roomTypeId') roomTypeId?: string,
 	): Promise<PaginateData<Room>> {
 		const guestAmount = guestAmountRaw
 			? parseInt(guestAmountRaw, 10)
@@ -193,6 +200,7 @@ export class RoomController {
 			limit,
 			checkin,
 			checkout,
+			roomTypeId,
 		);
 	}
 

--- a/src/modules/room/room.service.ts
+++ b/src/modules/room/room.service.ts
@@ -437,6 +437,7 @@ export class RoomService {
 		limit = 10,
 		checkinDate?: Date,
 		checkoutDate?: Date,
+		roomTypeId?: string,
 	): Promise<PaginateData<Room>> {
 		const skip = (page - 1) * limit;
 
@@ -537,6 +538,14 @@ export class RoomService {
 			},
 		];
 
+		if (roomTypeId) {
+			pipeline.unshift({
+				$match: {
+					roomTypeId: roomTypeId,
+				},
+			});
+		}
+
 		const match: any = {};
 		if (amenities && amenities.length > 0) {
 			match['roomType.amenities'] = { $all: amenities };
@@ -560,6 +569,7 @@ export class RoomService {
 				{ 'roomType.amenities': { $regex: searchKeyFeature, $options: 'i' } },
 			];
 		}
+
 		if (Object.keys(match).length > 0) {
 			pipeline.push({ $match: match });
 		}


### PR DESCRIPTION
This pull request includes changes to the `RoomController` and `RoomService` classes to add support for filtering rooms by `roomTypeId`. The most important changes include adding the `roomTypeId` query parameter and updating the service to handle this new parameter.

Changes to `RoomController`:

* Added `roomTypeId` as an optional query parameter in the `filterRoomsByRoomTypeFields` method (`src/modules/room/room.controller.ts`). [[1]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R151-R156) [[2]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R170) [[3]](diffhunk://#diff-39dda088cba1b22e7a2d0f75bd0511dfd7fa34a989e049fd7765be74c0f29da5R203)

Changes to `RoomService`:

* Added `roomTypeId` as an optional parameter in the `filterRooms` method (`src/modules/room/room.service.ts`).
* Updated the query pipeline to include a match for `roomTypeId` if it is provided (`src/modules/room/room.service.ts`). [[1]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8R541-R548) [[2]](diffhunk://#diff-9db327cad03848f33a60464cf2758036091d30a1b82077f8af326683286baef8R572)