### PR TITLE
feat: add phoneNumber field as optional in updateUser and changeProfile DTOs

### DIFF
--- a/src/modules/user/dto/request/changeProfile.request.dto.ts
+++ b/src/modules/user/dto/request/changeProfile.request.dto.ts
@@ -4,4 +4,5 @@ import { UpdateUserRequestDTO } from './updateUser.request.dto';
 export class ChangeProfileRequestDTO extends PickType(UpdateUserRequestDTO, [
 	'firstName',
 	'lastName',
+	'phoneNumber',
 ]) {}

--- a/src/modules/user/dto/request/updateUser.request.dto.ts
+++ b/src/modules/user/dto/request/updateUser.request.dto.ts
@@ -57,4 +57,13 @@ export class UpdateUserRequestDTO {
 	@IsOptional()
 	@IsString()
 	serviceTypeId: string;
+
+	@ApiProperty({
+		description: 'Phone number of the user',
+		example: '1234567890',
+		required: false,
+	})
+	@IsOptional()
+	@IsString()
+	phoneNumber: string;
 }


### PR DESCRIPTION
This pull request includes changes to the `ChangeProfileRequestDTO` and `UpdateUserRequestDTO` classes to add a new `phoneNumber` property. These changes ensure that the user's phone number can be included in profile updates.

Changes to DTO classes:

* [`src/modules/user/dto/request/changeProfile.request.dto.ts`](diffhunk://#diff-fd5df3be54362a15253840094119e6c3a8f574b66e03e62a9d301cdf7f02d1cdR7): Added `phoneNumber` to the list of properties in `ChangeProfileRequestDTO`.
* [`src/modules/user/dto/request/updateUser.request.dto.ts`](diffhunk://#diff-0e7accb149ee6c94829bf31548b39d45abea02ceeb9036c46b40df6c2ad625d8R60-R68): Added `phoneNumber` property with appropriate decorators and API documentation to `UpdateUserRequestDTO`.