### PR TITLE
feat: update Dockerfile to include Puppeteer dependencies and refactor email service to generate PDFs using Puppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,20 @@
 # Development stage
 FROM node:lts-alpine as development
 
+RUN apk add --no-cache \
+  chromium \
+  nss \
+  freetype \
+  freetype-dev \
+  harfbuzz \
+  ca-certificates \
+  ttf-freefont \
+  nodejs \
+  yarn
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
 WORKDIR /usr/src/app
 
 ARG NODE_ENV=development
@@ -19,10 +33,22 @@ CMD [ "npm", "run", "start:dev" ]
 # Production stage
 FROM node:20-alpine as production
 
-ARG NODE_ENV=production
-ENV NODE_ENV=${NODE_ENV}
+RUN apk add --no-cache \
+  chromium \
+  nss \
+  freetype \
+  freetype-dev \
+  harfbuzz \
+  ca-certificates \
+  ttf-freefont
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 WORKDIR /usr/src/app
+
+ARG NODE_ENV=production
+ENV NODE_ENV=${NODE_ENV}
 
 COPY package*.json ./
 


### PR DESCRIPTION
This pull request includes significant updates to the Docker configuration and the `EmailService` class to improve PDF generation using Puppeteer instead of `html-pdf`. The most important changes include updating the `Dockerfile` to install necessary dependencies for Puppeteer and modifying the `EmailService` to use Puppeteer for PDF generation.

### Dockerfile updates:

* Added installation of Chromium and other dependencies required for Puppeteer in both development and production stages. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R4-R17) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R52)
* Set environment variables `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` and `PUPPETEER_EXECUTABLE_PATH` to configure Puppeteer. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R4-R17) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L22-R52)

### EmailService updates:

* Replaced `html-pdf` with `puppeteer` for PDF generation in `src/modules/email/email.service.ts`.
* Updated the method to launch Puppeteer, set content, and generate PDF with custom header and footer templates.