### PR TITLE
fix: correct price calculation in booking service to reflect item price only

### DIFF
--- a/src/modules/booking/booking.service.ts
+++ b/src/modules/booking/booking.service.ts
@@ -414,7 +414,7 @@ export class BookingService {
 			customer.firstName,
 			items.map((item) => ({
 				name: item.name,
-				price: item.price * item.quantity,
+				price: item.price,
 				quantity: item.quantity,
 			})),
 			invoice.checkoutUrl,


### PR DESCRIPTION
This pull request includes a change to the `BookingService` class in the `src/modules/booking/booking.service.ts` file. The change involves modifying the way the price of an item is calculated in the `items.map` function.

* [`src/modules/booking/booking.service.ts`](diffhunk://#diff-b5a7938ee79396bd5d2b13a7daacdf1ea5facaab73b95c0b4dfd044004c2a5c1L417-R417): Updated the `items.map` function to use the item's price directly instead of multiplying the price by the quantity.